### PR TITLE
Fix sciter::host::call_function error checking

### DIFF
--- a/include/sciter-x-host-callback.h
+++ b/include/sciter-x-host-callback.h
@@ -187,7 +187,7 @@ namespace sciter
         SCITER_VALUE rv;
         BOOL r = SciterCall(hwnd, name, argc, argv, &rv);
 #if !defined(SCITER_SUPPRESS_SCRIPT_ERROR_THROW)
-      if( (r != SCDOM_OK) && rv.is_error_string())
+      if(r == FALSE && rv.is_error_string())
         throw sciter::script_error(aux::w2a(rv.get(WSTR(""))));
 #endif
         assert(r); r = r;


### PR DESCRIPTION
Copy-paste issue, SciterCall returns BOOL, but checked as SCDOM_RESULT.