### PR TITLE
Fix typo in doc comment

### DIFF
--- a/include/sciter-x-dom.hpp
+++ b/include/sciter-x-dom.hpp
@@ -145,7 +145,7 @@ namespace dom
     **/
     element(HELEMENT h)       { use(h); }
 
-  /**Copy constructo(void)r;
+  /**Copy constructor;
     * \param e \b #element
     **/
     element(const element& e) { use(e.he); }


### PR DESCRIPTION
`constructor` accidentally became `constructo(void)r;`