### PR TITLE
Fix sciter::host::call_function again.

### DIFF
--- a/include/sciter-x-host-callback.h
+++ b/include/sciter-x-host-callback.h
@@ -188,7 +188,7 @@ namespace sciter
         SCITER_VALUE rv;
         BOOL r = SciterCall(hwnd, name, argc, argv, &rv);
 #if !defined(SCITER_SUPPRESS_SCRIPT_ERROR_THROW)
-        if( (r != SCDOM_OK) && rv.is_error_string()) {
+        if( (r == FALSE) && rv.is_error_string()) {
           aux::w2a u8 (rv.get(WSTR("")));
           throw sciter::script_error(u8.c_str());
         }


### PR DESCRIPTION
It was accidentelly [broken](https://github.com/c-smile/sciter-sdk/commit/0ae9ce191e9f6a565d5b8d241fd93d8906883169#diff-ff495a40753f10cd59f9f8b4c1f1a84fL190) in 3.3.1.8 right after #17.