### PR TITLE
Add missed header for char16_t type.

### DIFF
--- a/include/sciter-x-types.h
+++ b/include/sciter-x-types.h
@@ -27,6 +27,7 @@
 #else
 
   #include <stdbool.h>
+  #include <uchar.h>
 
 #endif
 


### PR DESCRIPTION
Found in sciter-sdk/go-sciter#63.