### PR TITLE
Fix memory leak during thread spawn

### DIFF
--- a/include/sciter-x-threads.h
+++ b/include/sciter-x-threads.h
@@ -237,7 +237,7 @@
      template<typename F, typename P>
      inline void thread( F f, P p )
      {
-          new std::thread(f,p); // will leak the instance?
+          std::thread(f,p).detach();
      }
 
   }


### PR DESCRIPTION
Memory and resource, actually:

> `detach`: Separates the thread of execution from the thread object, allowing execution to continue independently. Any allocated resources will be freed once the thread exits.