### PR TITLE
Add support for std::initializer_list in sciter::value.

### DIFF
--- a/include/value.hpp
+++ b/include/value.hpp
@@ -23,6 +23,10 @@
   #include <string>
   #include <functional>
   #include <stdexcept>
+#ifdef CPP11
+  #include <initializer_list>
+  #include <utility>
+#endif
 
   #include "aux-slice.h"
   #include "aux-cvt.h"
@@ -141,6 +145,14 @@
         return v;
       }
 
+#ifdef CPP11
+      /** Create an array object initialized with the given values. */
+      static value make_array(std::initializer_list<value> list)
+      {
+        return value::make_array(static_cast<unsigned>(list.size()), list.begin());
+      }
+#endif
+
       /** Creates an empty json key/value map (object in JS terms) 
           The map can be populated by map.set_item(key,val); */
       static value make_map(  )
@@ -149,6 +161,19 @@
         ValueIntDataSet(&v, INT(0), T_MAP, 0);
         return v;
       }
+      
+#ifdef CPP11
+      /** Create a map object initialized with the given key/value pairs. */
+      static value make_map(std::initializer_list<std::pair<value, value>> list)
+      {
+        value result = value::make_map();
+        for (auto& item : list)
+        {
+          result.set_item(item.first, item.second);
+        }
+        return result;
+      }
+#endif
       
       static value secure_string(const WCHAR* s, size_t slen)
       {


### PR DESCRIPTION
This adds the support for quite convenient `sciter::value` compositions:

```cpp

using namespace sciter;

// '[ 1, 2.0, "three" ]'
value array = value::make_array( { 1, 2.0, L"three" } );

// '{ one: 1, two: 2 }'
value map = value::make_map(
  {
    { L"one", 1 },
    { L"two", 2},
  }
);

```

Unfortunately, we can't go further and construct `value`s directly from `initializer_list` because of the ambiguity between

```cpp
value(std::initializer_list<value> list);
value(std::initializer_list<std::pair<value, value>> list);
```

The following is parsed as array and not as std::pair:

```cpp

// '[ { name: "first" }, { name: "second" } '
sciter::value array_of_objects = sciter::value(
  { // array
    { // map
      { L"name", L"first" },    // <-- here
    },
    { // map
      { L"name", L"second" },
    },
  }
);

```

we have to explicitly state our intentions either with `make_array` or `make_map`.