### PR TITLE
fix: typos in sqlite.tis, lang.tis

### DIFF
--- a/samples/+lang/lang.tis
+++ b/samples/+lang/lang.tis
@@ -180,6 +180,7 @@ const Lang = function() {
     var fmt = xlation[text]; 
     if( !fmt ) { if(notfound) notfound[text] = #text; }
     else return typeof fmt == #function ? fmt.call(this, val) : fmt.replace("#",val.toString() );
+    return text;
   }
 
   // <output> updater

--- a/samples/sqlite/sqlite.tis
+++ b/samples/sqlite/sqlite.tis
@@ -77,7 +77,7 @@
     do {
       var row = [];
       for( var v in rs ) row.push(v);
-      data.push(item);
+      data.push(row);
     } while( rs.next() );
     return data;
   }


### PR DESCRIPTION
sqlite.tis: Fixing a typo.
lang.tis: `function translate` right now returns `{nothing?}` if there is no translation found, returning original text if no translation found.