### PR TITLE
Behavior tweaks

### DIFF
--- a/include/behaviors/behavior_native_textarea.cpp
+++ b/include/behaviors/behavior_native_textarea.cpp
@@ -53,6 +53,8 @@ struct native_textarea: public event_handler
                                  rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top,
                                  parent, NULL, THIS_HINSTANCE, 0);
 
+      ::SendMessage(this_hwnd, WM_SETFONT, (WPARAM)GetStockObject(DEFAULT_GUI_FONT), true);
+
       self.attach_hwnd(this_hwnd);
     }
     virtual void detached  (HELEMENT he ) 

--- a/samples/video/video-generator-behavior-demo.htm
+++ b/samples/video/video-generator-behavior-demo.htm
@@ -41,6 +41,14 @@
         };
         video.detach();
         host.root.$(body).append(video);
+
+        host.on("closing", function(evt) {
+          // detach
+          video.detach();
+          body.append(video);
+          $(#show-detached).value = false;
+        });
+
       } else {
         video.detach();
         self.$(body).append(video);


### PR DESCRIPTION
1. Set the default GUI font in the native text control (instead of the ugly one).
2. Properly handle the popup closing in the video generator sample (reattach the video element back to the host).